### PR TITLE
Fix bug where correct letter in wrong position doesn't appear on board

### DIFF
--- a/pages/[year]/[month]/[day].tsx
+++ b/pages/[year]/[month]/[day].tsx
@@ -104,7 +104,7 @@ export default function ArchivePage({ wordleData, params }) {
           return 'correct';
         if (solution.includes(letter) &&
           solution.split('').reduce((a,v) => (v===letter ? a+1 : a),0) // num of occurrences of letter in solution
-            >= board[rowIndex].split('').reduce((a,v) => (v===letter ? a+1 : a),0)) // num of occurrences of letter in guess
+            >= board[rowIndex].slice(0, i + 1).split('').reduce((a,v) => (v===letter ? a+1 : a),0)) // num of occurrences of letter in guess
           return 'present';
         return 'absent';
       });


### PR DESCRIPTION
When the guess has a repeated letter that occurs more often than in the solution, it will not appear. This happens for instance if the user guesses "falls" when the solution is "focal" because the 'L' appears more often in the guess than in the solution. 